### PR TITLE
Minor fix. Silently ignores duplicates.

### DIFF
--- a/kubcron/managers/jobs.py
+++ b/kubcron/managers/jobs.py
@@ -21,7 +21,9 @@ class JobManager(Manager):
 
     def create(self, namespace, definition):
         resp = self._post('/apis/batch/v1/namespaces/{}/jobs'.format(namespace), definition)
-        if resp.status_code != 201:
+        if resp.status_code == 409:
+            logging.info('Job already exists. Skipping.')
+        elif resp.status_code != 201:
             logging.error(resp.text)
             raise Exception('Invalid status code {} received when creating job'.format(resp.status_code))
         return resp.json()


### PR DESCRIPTION
I've noticed that I had *a lot* of crashes (as in 500+ over two days). Upon further investigation, this was due to the fact that that the worker tried to create the same job multiple times. I had annotated my jobs with `concurrencyPolicy`, but I later realized that this wasn't implemented. 

This fix simply tells the worker to silently ignore duplicates.